### PR TITLE
fix capi-worker issues when testing locally

### DIFF
--- a/compose_local_overrides.yaml
+++ b/compose_local_overrides.yaml
@@ -55,6 +55,8 @@ services:
         bind:
           propagation: rshared
   capi-worker:
+    environment:
+      - LOCAL_USER=${UID}:${GID}
     volumes:
       - type: bind
         source: ${PWD}/cp_root

--- a/compose_local_overrides.yaml
+++ b/compose_local_overrides.yaml
@@ -61,6 +61,9 @@ services:
         target: /cp_root
         bind:
           propagation: rshared
+    depends_on:
+      capi:
+        condition: service_healthy
   capi-background:
     volumes:
       - type: bind


### PR DESCRIPTION
When testing locally (using the dev environment (`make up`)), we noticed two issues:

1. capi-worker starts before capi created the user account in redis -> capi-worker fails and restarts (technically still works after some restarts)
2. capi-worker runs as root. This is not the case for capi-background. Running as root causes a `git unsafe repository` issue -> capi-worker won't start.  Alternative fix: running `git config --global --add safe.directory '*'` in the entry point of the capi.

This PR fixes both issues for the local dev setup.
I hope it helps other teams that are currently evaluating their CRS.

PS: It was great talking to you @ DefCon! :)